### PR TITLE
(PUP-3816/PUP-3832) Fixups for compiled Ruby 2.1.5 builds - 2.1.x-x86

### DIFF
--- a/ruby/bin/setrbvars.bat
+++ b/ruby/bin/setrbvars.bat
@@ -1,0 +1,14 @@
+@ECHO OFF
+REM Determine where is RUBY_BIN (where this script is)
+PUSHD %~dp0.
+SET RUBY_BIN=%CD%
+POPD
+
+REM Add RUBY_BIN to the PATH
+REM RUBY_BIN takes higher priority to avoid other tools
+REM conflict with our own (mainly the DevKit)
+SET PATH=%RUBY_BIN%;%PATH%
+SET RUBY_BIN=
+
+REM Display Ruby version
+ruby.exe -v

--- a/ruby/lib/ruby/2.1.0/dl.rb
+++ b/ruby/lib/ruby/2.1.0/dl.rb
@@ -5,7 +5,8 @@ begin
 rescue LoadError
 end
 
-warn "DL is deprecated, please use Fiddle"
+# http://stackoverflow.com/questions/15590450/ruby-2-0-0p0-irb-error-dl-is-deprecated-please-use-fiddle
+# warn "DL is deprecated, please use Fiddle"
 
 module DL
   # Returns true if DL is using Fiddle, the libffi wrapper.

--- a/ruby/lib/ruby/2.1.0/rubygems/commands/setup_command.rb
+++ b/ruby/lib/ruby/2.1.0/rubygems/commands/setup_command.rb
@@ -241,14 +241,14 @@ By default, this RubyGems will install gem as:
           bin_cmd_file = File.join Dir.tmpdir, "#{bin_file}.bat"
 
           File.open bin_cmd_file, 'w' do |file|
-            file.puts <<-TEXT
+            file.puts <<-SCRIPT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"#{File.basename(Gem.ruby).chomp('"')}" "#{dest_file}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"#{File.basename(Gem.ruby).chomp('"')}" "%~dpn0" %*
-TEXT
+@"%~dp0ruby.exe" "%~dpn0" %*
+SCRIPT
           end
 
           install bin_cmd_file, "#{dest_file}.bat", :mode => 0755

--- a/ruby/lib/ruby/2.1.0/rubygems/installer.rb
+++ b/ruby/lib/ruby/2.1.0/rubygems/installer.rb
@@ -657,14 +657,14 @@ TEXT
 
   def windows_stub_script(bindir, bin_file_name)
     ruby = File.basename(Gem.ruby).chomp('"')
-    return <<-TEXT
+    return <<-SCRIPT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"#{ruby}" "#{File.join(bindir, bin_file_name)}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"#{ruby}" "%~dpn0" %*
-TEXT
+@"%~dp0ruby.exe" "%~dpn0" %*
+SCRIPT
   end
 
   ##


### PR DESCRIPTION
This changeset updates our compiled Ruby 2.1.5 build with several changes that were previously applied to our vendored Ruby 2.0 builds. These commits remove an extraneous "DL is deprecated" warning, add back the "setrbvars.bat" file, and update gem's  'setup_command.rb' and 'installer.rb' files to install gems using the relative path to Ruby.
