### PR TITLE
(RE-4104) Allow vendored gems to failback to use Ruby on %PATH%

### DIFF
--- a/ruby/bin/catstomp.bat
+++ b/ruby/bin/catstomp.bat
@@ -3,4 +3,9 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*

--- a/ruby/bin/minitar.bat
+++ b/ruby/bin/minitar.bat
@@ -3,4 +3,9 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*

--- a/ruby/bin/stompcat.bat
+++ b/ruby/bin/stompcat.bat
@@ -3,4 +3,9 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*

--- a/ruby/lib/ruby/1.9.1/rubygems/commands/setup_command.rb
+++ b/ruby/lib/ruby/1.9.1/rubygems/commands/setup_command.rb
@@ -193,7 +193,12 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*
 SCRIPT
           end
 

--- a/ruby/lib/ruby/1.9.1/rubygems/installer.rb
+++ b/ruby/lib/ruby/1.9.1/rubygems/installer.rb
@@ -497,7 +497,12 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*
 SCRIPT
 
   end

--- a/ruby/lib/ruby/gems/1.9.1/specifications/win32-security-0.2.5.gemspec
+++ b/ruby/lib/ruby/gems/1.9.1/specifications/win32-security-0.2.5.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.licenses = ["Artistic 2.0"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "win32utils"
-  s.rubygems_version = "1.8.28"
+  s.rubygems_version = "1.8.24"
   s.summary = "A library for dealing with aspects of Windows security."
 
   if s.respond_to? :specification_version then

--- a/ruby/lib/ruby/site_ruby/1.9.1/rubygems/commands/setup_command.rb
+++ b/ruby/lib/ruby/site_ruby/1.9.1/rubygems/commands/setup_command.rb
@@ -193,7 +193,12 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*
 SCRIPT
           end
 

--- a/ruby/lib/ruby/site_ruby/1.9.1/rubygems/installer.rb
+++ b/ruby/lib/ruby/site_ruby/1.9.1/rubygems/installer.rb
@@ -491,7 +491,12 @@ IF NOT "%~f0" == "~f0" GOTO :WinNT
 ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
 GOTO :EOF
 :WinNT
-@"%~dp0ruby.exe" "%~dpn0" %*
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*
 SCRIPT
 
   end


### PR DESCRIPTION
This commit includes the patches from PUP-4077. To facilitate
CI using multiple versions of Ruby managed with Pik, this
allows our vendored gems to failback to using a Ruby that
exists on %PATH%, but only if Ruby is not available at %~dp0 first.