### PR TITLE
(PUP-4390) Patch win32-service gem 0.8.6 for 2003 - 1.9.3-x86

### DIFF
--- a/PUP-4390-win32-service-0.8.6-restore_win_2003_compat.patch
+++ b/PUP-4390-win32-service-0.8.6-restore_win_2003_compat.patch
@@ -1,0 +1,310 @@
+From c1ea91336c93ee937e7e4058c4659b001f511155 Mon Sep 17 00:00:00 2001
+From: "Ethan J. Brown" <Iristyle@github>
+Date: Tue, 14 Apr 2015 14:20:44 -0700
+Subject: (fix) tests should check version 0.8.6
+
+---
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb  | 2 +-
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb
+index a5577a9..e2bd71c 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb
+@@ -17,7 +17,7 @@ class TC_Daemon < Test::Unit::TestCase
+   end
+
+   test "version number is set properly" do
+-    assert_equal('0.8.4', Daemon::VERSION)
++    assert_equal('0.8.6', Daemon::VERSION)
+   end
+
+   test "constructor basic functionality" do
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+index d95d921..7d20877 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+@@ -52,7 +52,7 @@ class TC_Win32_Service < Test::Unit::TestCase
+   end
+
+   test "version number is expected value" do
+-    assert_equal('0.8.5', Win32::Service::VERSION)
++    assert_equal('0.8.6', Win32::Service::VERSION)
+   end
+
+   test "services basic functionality" do
+--
+1.9.5.msysgit.0
+
+From 35cf3064404892a74630496118c910e5b37bc5e8 Mon Sep 17 00:00:00 2001
+From: "Ethan J. Brown" <Iristyle@github>
+Date: Tue, 14 Apr 2015 14:22:48 -0700
+Subject: (fix) Use LanmanServer for tests instead of stisvc
+
+ - In testing on Windows 2008 server, 'stisvc' is a service that does
+   not exist.  Instead use LanmanServer which exists as far back as
+   Windows 2003, and supports stopping, pausing and resuming.
+---
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+index 7d20877..8c6c8ff 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+@@ -11,13 +11,13 @@ require 'socket'
+ class TC_Win32_Service < Test::Unit::TestCase
+   def self.startup
+     @@host = Socket.gethostname
+-    @@service_name = 'stisvc'
++    @@service_name = 'LanmanServer'
+     @@elevated = Win32::Security.elevated_security?
+   end
+
+   def setup
+-    @display_name = 'Windows Image Acquisition (WIA)'
+-    @service_name = 'stisvc'
++    @display_name = 'Server'
++    @service_name = 'LanmanServer'
+     @service_stat = nil
+     @services     = []
+
+--
+1.9.5.msysgit.0
+
+From e0bb3fe75d572c295b09f02998ae8df50367e629 Mon Sep 17 00:00:00 2001
+From: "Ethan J. Brown" <Iristyle@github>
+Date: Tue, 14 Apr 2015 11:48:50 -0700
+Subject: Restore Windows 2003 compatibility
+
+ - In commit f65181283b, support for a delayed_start option was added
+   so that ChangeServiceConfig2 could be used to configure a service
+   with a delayed start.  That information can also be retrieved via
+   QueryServiceConfig2 and the SERVICE_DELAYED_AUTO_START_INFO struct.
+
+   However, this constant does not exist prior to Vista / Windows 2008,
+   and thus this code outright fails on Windows 2003.
+
+   https://msdn.microsoft.com/en-us/library/windows/desktop/ms684935%28v=vs.85%29.aspx
+
+   Add a call to Windows GetVersionEx to retrieve the Windows version,
+   and guard against retrieving this additional information on
+   platforms where it is not supported.  Further, generate an error
+   when trying to set delayed_start in the call to configure on
+   unsupported platforms.
+
+   Since the current tests are written in test-unit, and there's no way
+   to mock the Windows version call, instead guard the tests on the
+   platform they're executing on.
+
+   Also note that there are test fixes included here because the
+   windows-security gem 0.3.1 doesn't work properly for detecting
+   elevated security on Windows 2003 and thus a number of tests fail as
+   a result.  Also note that the service dependency structure on Windows
+   2003 is different, and LanmanServer carries dependencies which make
+   tests fail.  On Windows 2003, a more appropriate service is the task
+   scheduler service (though on Windows 2008 it is not).
+---
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/service.rb                 | 37 +++++++++++++++++++++++++++++-------
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb       |  2 ++
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb         | 19 ++++++++++++++++++
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb           | 22 +++++++++++++++++----
+ ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb | 12 +++++++++++-
+ 5 files changed, 80 insertions(+), 12 deletions(-)
+
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/service.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/service.rb
+index 134adae..71c1f4d 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/service.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/service.rb
+@@ -495,6 +495,10 @@ module Win32
+         raise ArgumentError, 'No service_name specified'
+       end
+
++      if windows_version < 6 && options.include?(:delayed_start)
++        raise ArgumentError, 'delayed_start not supported on Windows 2003 and earlier editions'
++      end
++
+       service = opts.delete('service_name')
+       host = opts.delete('host')
+
+@@ -563,7 +567,7 @@ module Win32
+           FFI.raise_windows_error('ChangeServiceConfig2') unless bool
+         end
+
+-        if opts['delayed_start']
++        if windows_version >= 6 && opts['delayed_start']
+           delayed_start = SERVICE_DELAYED_AUTO_START_INFO.new
+           delayed_start[:fDelayedAutostart] = opts['delayed_start']
+
+@@ -1089,13 +1093,15 @@ module Win32
+                 description = ''
+               end
+
+-              delayed_start_buf = get_config2_info(handle_scs, SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
++              delayed_start = false
++              # delayed_start can only be read from the service after 2003 / XP
++              if windows_version >= 6
++                delayed_start_buf = get_config2_info(handle_scs, SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
+
+-              if delayed_start_buf.is_a?(FFI::MemoryPointer)
+-                delayed_start_info = SERVICE_DELAYED_AUTO_START_INFO.new(delayed_start_buf)
+-                delayed_start = delayed_start_info[:fDelayedAutostart]
+-              else
+-                delayed_start = false
++                if delayed_start_buf.is_a?(FFI::MemoryPointer)
++                  delayed_start_info = SERVICE_DELAYED_AUTO_START_INFO.new(delayed_start_buf)
++                  delayed_start = delayed_start_info[:fDelayedAutostart]
++                end
+               end
+             else
+               msg = "WARNING: The registry entry for the #{service_name} "
+@@ -1562,6 +1568,23 @@ module Win32
+       alias create new
+       alias getdisplayname get_display_name
+       alias getservicename get_service_name
++
++      @@win_ver = nil
++
++      # Private method that returns the Windows major version number.
++      def windows_version
++        return @@win_ver if @@win_ver
++
++        ver = OSVERSIONINFO.new
++        ver[:dwOSVersionInfoSize] = ver.size
++
++        unless GetVersionExW(ver)
++          raise SystemCallError.new('GetVersionEx', FFI.errno)
++        end
++
++        @@win_ver = ver[:dwMajorVersion]
++        @@win_ver
++      end
+     end
+   end
+ end
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb
+index 4b3d44a..70c5902 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb
+@@ -33,6 +33,8 @@ module Windows
+     attach_pfunc :WaitForSingleObject, [:handle, :dword], :dword, :blocking => true
+     attach_pfunc :WaitForMultipleObjects, [:dword, :ptr, :bool, :dword], :dword
+
++    attach_pfunc :GetVersionExW, [:ptr], :bool
++
+     ffi_lib :advapi32
+
+     callback :handler_ex, [:ulong, :ulong, :ptr, :ptr], :void
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb
+index dbcb5ad..7b50fa3 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb
+@@ -4,8 +4,11 @@ module Windows
+   module Structs
+     extend FFI::Library
+
++    typedef :uchar, :byte
++    typedef :uint16, :word
+     typedef :ulong, :dword
+
++
+     class SERVICE_STATUS < FFI::Struct
+       layout(
+         :dwServiceType, :ulong,
+@@ -117,5 +120,21 @@ module Windows
+         :Privileges, [LUID_AND_ATTRIBUTES, 1]
+       )
+     end
++
++    class OSVERSIONINFO < FFI::Struct
++      layout(
++        :dwOSVersionInfoSize, :dword,
++        :dwMajorVersion, :dword,
++        :dwMinorVersion, :dword,
++        :dwBuildNumber, :dword,
++        :dwPlatformId, :dword,
++        :szCSDVersion, [:uint16, 128],
++        :wServicePackMajor, :word,
++        :wServicePackMinor, :word,
++        :wSuiteMask, :word,
++        :wProductType, :byte,
++        :wReserved, :byte,
++      )
++    end
+   end
+ end
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+index 8c6c8ff..7c8e279 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+@@ -10,14 +10,18 @@ require 'socket'
+
+ class TC_Win32_Service < Test::Unit::TestCase
+   def self.startup
++    @@win_ver = Win32::Service.windows_version
+     @@host = Socket.gethostname
+-    @@service_name = 'LanmanServer'
+-    @@elevated = Win32::Security.elevated_security?
++    @@service_name = @@win_ver < 6 ? 'Schedule' : 'LanmanServer'
++    # win32-security 0.3.1 crashes on 2003, so just assume elevated there
++    @@elevated = false
++    @@elevated = Win32::Security.elevated_security? if @@win_ver >= 6
+   end
+
+   def setup
+-    @display_name = 'Server'
+-    @service_name = 'LanmanServer'
++    @win_ver = Win32::Service.windows_version
++    @display_name = @win_ver < 6 ? 'Task Scheduler' : 'Server'
++    @service_name = @win_ver < 6 ? 'Schedule' : 'LanmanServer'
+     @service_stat = nil
+     @services     = []
+
+@@ -74,6 +78,16 @@ class TC_Win32_Service < Test::Unit::TestCase
+     assert_kind_of(Struct::ServiceInfo, @services[0])
+   end
+
++  test "service objects all have delayed_start set to false on Windows versions older than 2003" do
++    omit_if(Win32::Service.windows_version >= 6)
++    Win32::Service.services.all? { |s| s.delayed_start == false }
++  end
++
++  test "some service objects have delayed_start set to true on Windows versions newer than 2003" do
++    omit_if(Win32::Service.windows_version < 6)
++    Win32::Service.services.any? { |s| s.delayed_start == true }
++  end
++
+   test "the host argument must be a string or an error is raised" do
+     assert_raise(TypeError){ Win32::Service.services(1) }
+   end
+diff --git a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb
+index 3fb2b53..dc57ada 100644
+--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb
++++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb
+@@ -64,11 +64,21 @@ class TC_Win32_Service_Configure < Test::Unit::TestCase
+     assert_equal('disabled', config_info.start_type)
+   end
+
+-  test "service start can be delayed" do
++  test "service start can be delayed on Windows versions newer than 2003" do
++    omit_if(Win32::Service.windows_version < 6)
+     service_configure(:start_type => Win32::Service::AUTO_START, :delayed_start => true)
+     assert_true(full_info.delayed_start)
+   end
+
++  test "service start cannot be delayed on Windows versions older than 2003" do
++    omit_if(Win32::Service.windows_version >= 6)
++    assert_raise(ArgumentError){
++      Win32::Service.configure(
++      :service_name => @@service,
++      :start_type => Win32::Service::AUTO_START, :delayed_start => true)
++    }
++  end
++
+   test "the configure method requires one argument" do
+     assert_raise(ArgumentError){ Win32::Service.configure }
+   end
+--
+1.9.5.msysgit.0
+

--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb
+++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/functions.rb
@@ -33,6 +33,8 @@ module Windows
     attach_pfunc :WaitForSingleObject, [:handle, :dword], :dword, :blocking => true
     attach_pfunc :WaitForMultipleObjects, [:dword, :ptr, :bool, :dword], :dword
 
+    attach_pfunc :GetVersionExW, [:ptr], :bool
+
     ffi_lib :advapi32
 
     callback :handler_ex, [:ulong, :ulong, :ptr, :ptr], :void

--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb
+++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/lib/win32/windows/structs.rb
@@ -4,7 +4,10 @@ module Windows
   module Structs
     extend FFI::Library
 
+    typedef :uchar, :byte
+    typedef :uint16, :word
     typedef :ulong, :dword
+
 
     class SERVICE_STATUS < FFI::Struct
       layout(
@@ -115,6 +118,22 @@ module Windows
       layout(
         :PrivilegeCount, :dword,
         :Privileges, [LUID_AND_ATTRIBUTES, 1]
+      )
+    end
+
+    class OSVERSIONINFO < FFI::Struct
+      layout(
+        :dwOSVersionInfoSize, :dword,
+        :dwMajorVersion, :dword,
+        :dwMinorVersion, :dword,
+        :dwBuildNumber, :dword,
+        :dwPlatformId, :dword,
+        :szCSDVersion, [:uint16, 128],
+        :wServicePackMajor, :word,
+        :wServicePackMinor, :word,
+        :wSuiteMask, :word,
+        :wProductType, :byte,
+        :wReserved, :byte,
       )
     end
   end

--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb
+++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_daemon.rb
@@ -17,7 +17,7 @@ class TC_Daemon < Test::Unit::TestCase
   end
 
   test "version number is set properly" do
-    assert_equal('0.8.4', Daemon::VERSION)
+    assert_equal('0.8.6', Daemon::VERSION)
   end
 
   test "constructor basic functionality" do

--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
+++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service.rb
@@ -10,14 +10,18 @@ require 'socket'
 
 class TC_Win32_Service < Test::Unit::TestCase
   def self.startup
+    @@win_ver = Win32::Service.windows_version
     @@host = Socket.gethostname
-    @@service_name = 'stisvc'
-    @@elevated = Win32::Security.elevated_security?
+    @@service_name = @@win_ver < 6 ? 'Schedule' : 'LanmanServer'
+    # win32-security 0.3.1 crashes on 2003, so just assume elevated there
+    @@elevated = false
+    @@elevated = Win32::Security.elevated_security? if @@win_ver >= 6
   end
 
   def setup
-    @display_name = 'Windows Image Acquisition (WIA)'
-    @service_name = 'stisvc'
+    @win_ver = Win32::Service.windows_version
+    @display_name = @win_ver < 6 ? 'Task Scheduler' : 'Server'
+    @service_name = @win_ver < 6 ? 'Schedule' : 'LanmanServer'
     @service_stat = nil
     @services     = []
 
@@ -52,7 +56,7 @@ class TC_Win32_Service < Test::Unit::TestCase
   end
 
   test "version number is expected value" do
-    assert_equal('0.8.5', Win32::Service::VERSION)
+    assert_equal('0.8.6', Win32::Service::VERSION)
   end
 
   test "services basic functionality" do
@@ -72,6 +76,16 @@ class TC_Win32_Service < Test::Unit::TestCase
     assert_nothing_raised{ Win32::Service.services{ |s| @services << s } }
     assert_kind_of(Array, @services)
     assert_kind_of(Struct::ServiceInfo, @services[0])
+  end
+
+  test "service objects all have delayed_start set to false on Windows versions older than 2003" do
+    omit_if(Win32::Service.windows_version >= 6)
+    Win32::Service.services.all? { |s| s.delayed_start == false }
+  end
+
+  test "some service objects have delayed_start set to true on Windows versions newer than 2003" do
+    omit_if(Win32::Service.windows_version < 6)
+    Win32::Service.services.any? { |s| s.delayed_start == true }
   end
 
   test "the host argument must be a string or an error is raised" do

--- a/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb
+++ b/ruby/lib/ruby/gems/1.9.1/gems/win32-service-0.8.6/test/test_win32_service_configure.rb
@@ -64,9 +64,19 @@ class TC_Win32_Service_Configure < Test::Unit::TestCase
     assert_equal('disabled', config_info.start_type)
   end
 
-  test "service start can be delayed" do
+  test "service start can be delayed on Windows versions newer than 2003" do
+    omit_if(Win32::Service.windows_version < 6)
     service_configure(:start_type => Win32::Service::AUTO_START, :delayed_start => true)
     assert_true(full_info.delayed_start)
+  end
+
+  test "service start cannot be delayed on Windows versions older than 2003" do
+    omit_if(Win32::Service.windows_version >= 6)
+    assert_raise(ArgumentError){
+      Win32::Service.configure(
+      :service_name => @@service,
+      :start_type => Win32::Service::AUTO_START, :delayed_start => true)
+    }
   end
 
   test "the configure method requires one argument" do


### PR DESCRIPTION
 - As part of PUP-1283, the win32-service gem was upgraded to 0.8.5 from
   0.7.2 on 7/3/2014.  Unfortunately, this picked up a bug introduced
   to the win32-service gem that broke service enumeration under
   Windows 2003 in commit:
   https://github.com/djberg96/win32-service/commit/f65181283bd8f1f51d6f4dca3f38cbbebcaf0b60

   Support for SERVICE_DELAYED_AUTO_START_INFO was added as part of this
   change to support configuring and retrieving delayed start service
   status, but this startup type is not supported on 2003.  Simply
   executing the code yields the error:

   Error: Could not run: The system call level is not correct. -
   QueryServiceConfig2: The system call level is not correct.

 - A PR is outstanding against the gem, but until then, this patch and
   the patched contents of the vendored gem will remain in effect until
   0.8.7 ships and our vendored bits can be updated accordingly.